### PR TITLE
docs: add manual Messages sticker verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 ## Testing guidance
 
 - No XCTest target is present; `make check` is the maintained static regression gate and also parses the Xcode project when `xcodebuild` is available.
+- `make check` and `make xcode-build` do not prove Messages-host interaction; record the exact Xcode/iOS runtime and separately exercise sticker selection, preview, send, transcript, and VoiceOver behavior.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
 
@@ -51,6 +52,7 @@
 - Preserve case-insensitive PNG discovery, exact discovered resource paths, extension-only asset-name normalization, and browser reload ownership after every load attempt.
 - Keep every bundled sticker structurally valid. The baseline parses PNG chunks, verifies CRCs and boundaries, requires `IHDR`, image data, and terminal `IEND`, and rejects trailing bytes.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- Manual verification must not be reported complete from static checks or an unsigned build alone.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Added a version-recorded manual Messages checklist for sticker selection,
+  preview, send, transcript, VoiceOver, privacy, logging, and failure evidence.
+- Distinguished static and unsigned-build success from completed Messages-host
+  interaction.
 - Decode bundled Twemoji filename scalars into Unicode sticker accessibility
   descriptions instead of exposing hexadecimal asset identifiers.
 - Validate all 834 asset stems and preserve a fail-closed filename fallback.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ cd emoji-imessage-app
 ```
 
 This project uses an iOS 12 deployment baseline with Swift 5 source and current
-UIKit/Foundation API names.
+UIKit/Foundation API names. The reviewed hosted build uses Xcode 16.4; record
+the exact Xcode and iOS runtime when performing manual verification.
 
 ## Running or Using the Project
 
@@ -102,6 +103,38 @@ machines.
 For full Apple-platform verification, open `Twemoji.xcodeproj` in Xcode and run
 the app/extension on an iOS simulator or device.
 
+### Manual Messages Verification
+
+The maintained baseline is Swift 5 with an iOS 12 minimum and a reviewed
+Xcode 16.4 hosted build; record the exact runtime used because that build does not
+establish behavior on every supported iOS version.
+
+Complete `make check` and `make xcode-build` before testing the user-visible
+flow. Those commands prove repository invariants and compilation, not Messages
+host interaction.
+
+1. Record the Xcode version, iOS simulator or device version, and device model.
+2. Select and run the `MessagesExtension` scheme. When Messages opens, enter a
+   test conversation, open the app drawer, and select the Twemoji extension.
+3. Confirm the sticker browser is populated, scroll it, and reopen the extension
+   to confirm stale or duplicated stickers do not appear.
+4. Tap one bundled sticker and confirm it appears in the Messages input field.
+   Use the Messages send control and confirm the same sticker appears in the
+   conversation transcript. Also press and hold a sticker and drag it onto an
+   existing message balloon to verify the standard sticker attachment path.
+5. With VoiceOver enabled, focus one single-scalar sticker and one multi-scalar
+   sticker such as a keycap. Confirm each accessible description announces the
+   emoji rather than a raw hexadecimal asset stem.
+6. Confirm the extension requests no permissions, performs no network activity,
+   and prints no bundle paths, asset names, or local errors to the console.
+
+Record failures with the exact toolchain/runtime and whether the browser was
+empty, a sticker was missing, preview or send failed, stale content remained,
+the extension crashed, a raw asset stem was announced, private path/error data
+was logged, or unexpected permission/network behavior occurred. Do not mark
+manual verification complete unless the selection, preview, send, transcript,
+and accessibility checks were actually exercised.
+
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 
 ## Configuration and Secrets
@@ -157,6 +190,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   migration and hosted simulator build contract.
 - See `docs/plans/2026-06-13-emoji-accessible-sticker-descriptions.md` for the
   Unicode sticker accessibility label boundary.
+- See `docs/plans/2026-06-13-emoji-manual-sticker-verification.md` for the
+  Messages selection, send, and VoiceOver verification checklist.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,12 @@ terminal `IEND` without trailing bytes.
 
 Sticker accessibility labels decode only validated hexadecimal Unicode scalar
 stems and fall back to the extensionless asset name on future invalid input.
+Manual Messages verification should confirm that VoiceOver announces both a
+single-scalar and multi-scalar sticker without exposing raw hexadecimal asset
+stems. Also confirm that opening, previewing, and sending a sticker causes no
+unexpected permission prompt, network activity, or private path/error logging.
+Static checks and an unsigned simulator build do not prove this runtime privacy
+boundary; record the exact Xcode and iOS runtime used for the manual check.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -53,12 +53,13 @@ Current baseline:
   macOS runner so the Swift 5 host app and extension compile before review.
 - The maintenance gate parses every bundled sticker PNG and verifies complete
   chunk structure and CRC integrity before review.
+- Manual Messages verification is documented separately from static/build
+  evidence and covers sticker selection, preview, send, transcript appearance,
+  VoiceOver descriptions, stale content, logging, permissions, and networking.
 
 Next priorities:
 
-- Document Xcode and iOS version expectations
 - Clarify emoji asset licensing and update process
-- Add manual verification notes for selecting and sending an emoji
 
 Contribution rules:
 

--- a/docs/plans/2026-06-13-emoji-manual-sticker-verification.md
+++ b/docs/plans/2026-06-13-emoji-manual-sticker-verification.md
@@ -2,7 +2,7 @@
 title: Emoji iMessage Manual Sticker Verification
 type: documentation
 date: 2026-06-13
-status: planned
+status: completed
 ---
 
 # Emoji iMessage Manual Sticker Verification
@@ -56,15 +56,19 @@ must clearly separate required steps from locally unperformed platform results.
   described as completed simulator interaction.
 - **Covers:** R7
 
-## Verification Plan
+## Verification
 
-- Run `make check`, `make lint`, `make test`, and `make build` on Linux.
-- Apply isolated mutations for removed select/send, accessibility, failure,
-  prerequisite, platform-limitation, roadmap, and plan-evidence guidance.
-- Inspect exact paths, signing/secret-like additions, generated artifacts, and
-  staged files before committing.
-- Do not claim local Xcode, simulator, Messages, VoiceOver, or device execution;
-  require the hosted macOS build before completing exact-head evidence.
+- `make check`, `make lint`, `make test`, and `make build` passed the portable
+  maintenance baseline on Linux.
+- Eight isolated hostile mutations were rejected for removed select/send,
+  accessibility, failure, prerequisite, platform-limitation, roadmap, and
+  completed-plan evidence.
+- Shell syntax, `git diff --check`, exact-path review, signing/secret-like
+  addition inspection, generated-artifact inspection, and staged-path review
+  passed.
+- Xcode, simulator/device Messages interaction, sticker selection/send, and
+  VoiceOver were not performed locally. The hosted macOS build remains required
+  on the exact implementation head before tracker completion.
 
 ## Risks
 

--- a/docs/plans/2026-06-13-emoji-manual-sticker-verification.md
+++ b/docs/plans/2026-06-13-emoji-manual-sticker-verification.md
@@ -1,0 +1,75 @@
+---
+title: Emoji iMessage Manual Sticker Verification
+type: documentation
+date: 2026-06-13
+status: planned
+---
+
+# Emoji iMessage Manual Sticker Verification
+
+## Summary
+
+Document a bounded, reproducible Messages verification checklist for opening
+the extension, selecting a bundled sticker, sending it, and checking the
+accessible description without conflating those manual results with the hosted
+unsigned build.
+
+## Problem Frame
+
+The repository has a portable static gate and an Xcode 16.4 unsigned simulator
+build, but its usage guidance stops at opening the project and running a scheme.
+The vision still calls for manual notes covering the user-visible sticker flow.
+This Linux environment cannot launch Messages or VoiceOver, so the checklist
+must clearly separate required steps from locally unperformed platform results.
+
+## Requirements
+
+- R1. State the maintained Swift 5, iOS 12 minimum, and Xcode 16.4 verification
+  baseline without claiming broader runtime support.
+- R2. Identify the host app and Messages extension flow needed to expose the
+  sticker browser in a simulator or device conversation.
+- R3. Require selecting a bundled emoji, confirming its preview, sending it,
+  and confirming it appears in the transcript.
+- R4. Include a VoiceOver/accessibility-description check for at least one
+  single-scalar and one multi-scalar sticker.
+- R5. Include failure notes for an empty browser, missing stickers, send
+  failures, stale content, crashes, path/error logging, and unexpected network
+  or permission behavior.
+- R6. Keep `make check` and `make xcode-build` as prerequisites, and state that
+  they do not prove Messages-host interaction.
+- R7. Enforce the checklist, roadmap update, and truthful completed evidence in
+  the static repository gate.
+
+## Implementation Units
+
+### U1. Add Manual Verification Guidance
+
+- **Files:** `README.md`, `AGENTS.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- **Goal:** Document the supported toolchain and exact user-visible verification
+  flow, expected results, and failure-reporting boundary.
+- **Covers:** R1, R2, R3, R4, R5, R6
+
+### U2. Enforce Truthful Documentation Evidence
+
+- **Files:** `scripts/check-baseline.sh`, this plan
+- **Goal:** Require the checklist and prevent static/build results from being
+  described as completed simulator interaction.
+- **Covers:** R7
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` on Linux.
+- Apply isolated mutations for removed select/send, accessibility, failure,
+  prerequisite, platform-limitation, roadmap, and plan-evidence guidance.
+- Inspect exact paths, signing/secret-like additions, generated artifacts, and
+  staged files before committing.
+- Do not claim local Xcode, simulator, Messages, VoiceOver, or device execution;
+  require the hosted macOS build before completing exact-head evidence.
+
+## Risks
+
+- Simulator and device behavior can vary by Xcode and iOS runtime; the checklist
+  records the reviewed Xcode 16.4/iOS 12 baseline and asks contributors to state
+  the exact runtime they exercised.
+- Documentation cannot replace UI automation or XCTest coverage, neither of
+  which is currently present.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -22,6 +22,7 @@ CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-emoji-imessage-ci-baseline.md"
 PNG_INTEGRITY_PLAN="$ROOT_DIR/docs/plans/2026-06-10-emoji-png-integrity.md"
 SWIFT5_PLAN="$ROOT_DIR/docs/plans/2026-06-12-swift5-xcode-build-gate.md"
 ACCESSIBLE_DESCRIPTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-emoji-accessible-sticker-descriptions.md"
+MANUAL_VERIFICATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-emoji-manual-sticker-verification.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -59,6 +60,7 @@ for path in \
   "docs/plans/2026-06-10-emoji-png-integrity.md" \
   "docs/plans/2026-06-12-swift5-xcode-build-gate.md" \
   "docs/plans/2026-06-13-emoji-accessible-sticker-descriptions.md" \
+  "docs/plans/2026-06-13-emoji-manual-sticker-verification.md" \
   "docs/plans/2026-06-08-emoji-imessage-sticker-reload.md" \
   "docs/plans/2026-06-08-emoji-imessage-app-maintenance-baseline.md"; do
   require_file "$path"
@@ -330,6 +332,60 @@ for document in "$README" "$ROOT_DIR/SECURITY.md" "$VISION" "$ROOT_DIR/CHANGES.m
     exit 1
   fi
 done
+
+python3 - "$README" <<'PY'
+from pathlib import Path
+import sys
+
+readme = Path(sys.argv[1]).read_text(encoding="utf-8")
+heading = "### Manual Messages Verification"
+try:
+    section = readme.split(heading, 1)[1].split("\n## ", 1)[0]
+except IndexError:
+    raise SystemExit("README must contain one Manual Messages Verification section.")
+
+contracts = (
+    "make check",
+    "make xcode-build",
+    "Xcode 16.4",
+    "run the `MessagesExtension` scheme",
+    "app drawer",
+    "Messages input field",
+    "Messages send control",
+    "conversation transcript",
+    "drag it onto an",
+    "single-scalar sticker",
+    "multi-scalar",
+    "raw hexadecimal asset stem",
+    "a sticker was missing",
+    "unexpected permission/network behavior",
+    "manual verification complete unless",
+)
+for contract in contracts:
+    if contract not in section:
+        raise SystemExit(f"Manual Messages verification contract is missing: {contract}")
+PY
+
+if ! grep -Fq "static and unsigned-build success" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "Manual Messages verification is documented separately" "$VISION" ||
+  ! grep -Fq "do not prove Messages-host interaction" "$AGENTS" ||
+  ! grep -Fq "Static checks and an unsigned simulator build do not prove" "$ROOT_DIR/SECURITY.md"; then
+  printf '%s\n' "Project guidance must separate build evidence from Messages-host verification." >&2
+  exit 1
+fi
+
+if grep -Fq "Add manual verification notes for selecting and sending an emoji" "$VISION"; then
+  printf '%s\n' "VISION must move completed manual sticker guidance out of next priorities." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$MANUAL_VERIFICATION_PLAN" ||
+  ! grep -Fq "hostile mutations were rejected" "$MANUAL_VERIFICATION_PLAN" ||
+  ! grep -Fq "not performed locally" "$MANUAL_VERIFICATION_PLAN" ||
+  ! grep -Fq "hosted macOS build" "$MANUAL_VERIFICATION_PLAN"; then
+  printf '%s\n' "Manual sticker verification plan must record truthful completed evidence." >&2
+  exit 1
+fi
 
 if ! grep -Fq "private func isPNGResource" "$BROWSER_VIEW" ||
   ! grep -Fq 'pathExtension.lowercased() == "png"' "$BROWSER_VIEW" ||


### PR DESCRIPTION
## Summary

Contributors now have a reproducible Messages checklist that distinguishes successful compilation from actually selecting, composing, sending, attaching, and hearing bundled stickers in the host app.

## Baseline

Compilation and static checks did not provide a structured way to record real Messages-host sticker behavior, accessibility output, stale state, or runtime failures without overstating what had been verified.

## Improvements

- records the exact Xcode, iOS runtime, and device or simulator used
- runs the `MessagesExtension` scheme and verifies browser population and stale-state behavior
- confirms tap-to-input, send-to-transcript, and drag-to-balloon interactions
- checks single-scalar and multi-scalar VoiceOver descriptions
- records missing assets, crashes, stale content, logging, permission prompts, and network activity as failures
- explicitly prevents `make check` or an unsigned build from being reported as completed Messages-host verification

The static gate parses the checklist section itself, so prerequisites and expected results cannot be removed while equivalent words elsewhere in the README mask the regression.

## Validation

- `make check`, `make lint`, `make test`, and `make build`
- eight isolated hostile documentation and evidence mutations rejected
- plan-based review found and fixed the Messages compose/send flow and section-scoping weakness
- exact seven-path review, shell syntax, whitespace, signing/secret-like additions, and generated-artifact inspection

## Risk

Xcode, Messages, VoiceOver, and simulator/device interaction were not performed on the Linux host. No manual runtime result is claimed.

## Follow-Ups

- Complete the exact-head hosted macOS build and the documented Messages-host verification before claiming runtime completion.
- This PR is stacked on `lfg/emoji-imessage-accessible-descriptions-20260613` (PR #4); preserve that delivery order.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this update changes pull request metadata only and has no production/runtime impact.
