### PR TITLE
Make verification location independent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 
 - Install dependencies: no repository-specific install command is documented.
 - Full baseline: `make check`
+- Make targets resolve repository paths from the Makefile location and must
+  remain callable from an external working directory.
 - Lint/static checks: `make lint`
 - Tests: `make test`
 - Build: `make build`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Made the portable checker and Xcode project targets resolve paths from the
+  Makefile location so they work from external working directories.
+
 ## 2026-06-13
 
 - Removed the Messages extension storyboard's template label and constraints so

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: build check lint test xcode-list xcode-build
 
+override ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 XCODEBUILD ?= xcodebuild
 
 check:
-	@scripts/check-baseline.sh
+	@"$(ROOT)scripts/check-baseline.sh"
 
 lint: check
 
@@ -12,7 +13,7 @@ test: check
 build: check
 
 xcode-list:
-	@$(XCODEBUILD) -list -project Twemoji.xcodeproj
+	@$(XCODEBUILD) -list -project "$(ROOT)Twemoji.xcodeproj"
 
 xcode-build:
-	@$(XCODEBUILD) -project Twemoji.xcodeproj -target Twemoji -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=YES build
+	@$(XCODEBUILD) -project "$(ROOT)Twemoji.xcodeproj" -target Twemoji -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=YES build

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Xcode. When `xcodebuild` is installed, the baseline checks that Xcode can read
 `Twemoji.xcodeproj`; `make xcode-build` performs an unsigned iPhone Simulator
 build of the host app and Messages extension.
 
+All Make targets resolve repository files from the Makefile location, so the
+same commands also work when the Makefile is invoked from another directory.
+
 Bundled sticker validation parses every PNG chunk, verifies chunk boundaries
 and CRCs, requires a valid initial `IHDR`, positive dimensions, image data, and
 a terminal `IEND`, and rejects trailing bytes. This catches resource corruption

--- a/docs/plans/2026-06-14-emoji-location-independent-make.md
+++ b/docs/plans/2026-06-14-emoji-location-independent-make.md
@@ -1,0 +1,66 @@
+# Make Verification Location Independent
+
+status: completed
+
+## Context
+
+The documented Make targets invoke the baseline script and Xcode project with
+paths relative to the caller's current directory. `make check` passes from the
+repository root but fails when the same Makefile is invoked from an external
+working directory, making automation dependent on ambient shell location.
+
+## Requirements
+
+- R1. Derive the repository root from the loaded Makefile path.
+- R2. Prevent an environment variable from overriding the trusted root.
+- R3. Resolve the baseline script and both Xcode project arguments from that
+  root.
+- R4. Preserve target names, simulator build flags, Swift/iOS settings, and
+  hosted macOS coverage.
+- R5. Add mutation-sensitive static contracts and completed plan evidence.
+
+## Scope Boundaries
+
+- Do not modify Swift, storyboard, project, workflow, asset, signing, or
+  dependency behavior.
+- Do not claim a local Xcode build on Linux where `xcodebuild` is not installed.
+- Do not merge or close any stacked pull request without owner authorization.
+
+## Implementation
+
+- Define an override-protected absolute `ROOT` from `MAKEFILE_LIST`.
+- Use `ROOT` for the portable checker and `Twemoji.xcodeproj` paths.
+- Extend the baseline, contributor guidance, and change record for the
+  location-independent contract.
+
+## Verification
+
+- Run `make check` from the repository root and an external working directory.
+- Exercise `xcode-list` and `xcode-build` command construction with a bounded
+  fake `XCODEBUILD` executable because xcodebuild is not installed locally.
+- Run isolated hostile mutations for root derivation, script/project path use,
+  documentation, and completed plan evidence.
+- Audit the exact diff, generated artifacts, workflow/project preservation,
+  and credential-like additions before committing.
+
+## Work Completed
+
+- Added an override-protected absolute repository root derived from the loaded
+  Makefile path.
+- Resolved the portable baseline script and both Xcode project arguments from
+  that root while preserving all existing target names and build flags.
+- Added static contracts and synchronized contributor/change documentation for
+  location-independent invocation.
+
+## Verification Completed
+
+- `make check` passed from the repository root and an external working
+  directory with a poisoned `ROOT` environment value.
+- A bounded fake Xcode driver captured absolute `Twemoji.xcodeproj` paths for
+  both `xcode-list` and `xcode-build`, including every existing simulator and
+  unsigned-build flag; xcodebuild is not installed on this Linux host, so no
+  local Xcode build is claimed.
+- Six isolated hostile mutations were rejected across root protection, script
+  and project path resolution, documentation, and completed plan evidence.
+- Exact-path diff, workflow/project preservation, generated-artifact,
+  whitespace, shell, and credential-like addition audits passed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -25,6 +25,7 @@ SWIFT5_PLAN="$ROOT_DIR/docs/plans/2026-06-12-swift5-xcode-build-gate.md"
 ACCESSIBLE_DESCRIPTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-emoji-accessible-sticker-descriptions.md"
 MANUAL_VERIFICATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-emoji-manual-sticker-verification.md"
 STORYBOARD_PLACEHOLDER_PLAN="$ROOT_DIR/docs/plans/2026-06-13-emoji-storyboard-placeholder-removal.md"
+LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-14-emoji-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -64,6 +65,7 @@ for path in \
   "docs/plans/2026-06-13-emoji-accessible-sticker-descriptions.md" \
   "docs/plans/2026-06-13-emoji-manual-sticker-verification.md" \
   "docs/plans/2026-06-13-emoji-storyboard-placeholder-removal.md" \
+  "docs/plans/2026-06-14-emoji-location-independent-make.md" \
   "docs/plans/2026-06-08-emoji-imessage-sticker-reload.md" \
   "docs/plans/2026-06-08-emoji-imessage-app-maintenance-baseline.md"; do
   require_file "$path"
@@ -246,15 +248,35 @@ if ! grep -Fq "Signing certificates" "$ROOT_DIR/SECURITY.md" ||
   exit 1
 fi
 
-if ! grep -Fq "lint: check" "$ROOT_DIR/Makefile" ||
+if ! grep -Fq 'override ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq '"$(ROOT)scripts/check-baseline.sh"' "$ROOT_DIR/Makefile" ||
+  [ "$(grep -Fc '"$(ROOT)Twemoji.xcodeproj"' "$ROOT_DIR/Makefile")" -ne 2 ] ||
+  grep -Fq '@scripts/check-baseline.sh' "$ROOT_DIR/Makefile" ||
+  grep -Fq -- '-project Twemoji.xcodeproj' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq "lint: check" "$ROOT_DIR/Makefile" ||
   ! grep -Fq "test: check" "$ROOT_DIR/Makefile" ||
   ! grep -Fq "build: check" "$ROOT_DIR/Makefile" ||
   ! grep -Fq "xcode-build:" "$ROOT_DIR/Makefile" ||
-  ! grep -Fq "Twemoji.xcodeproj -target Twemoji -sdk iphonesimulator" "$ROOT_DIR/Makefile" ||
+  ! grep -Fq '"$(ROOT)Twemoji.xcodeproj" -target Twemoji -sdk iphonesimulator' "$ROOT_DIR/Makefile" ||
   ! grep -Fq "CODE_SIGNING_ALLOWED=NO" "$ROOT_DIR/Makefile" ||
   ! grep -Fq "ONLY_ACTIVE_ARCH=NO" "$ROOT_DIR/Makefile" ||
   ! grep -Fq "DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=YES" "$ROOT_DIR/Makefile"; then
   printf '%s\n' "Makefile must expose lint, test, and build aliases for the baseline gate." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "external working directory" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "hostile mutations" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "xcodebuild is not installed" "$LOCATION_INDEPENDENT_MAKE_PLAN"; then
+  printf '%s\n' "Location-independent Make plan must record truthful completed verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Makefile location" "$README" ||
+  ! grep -Fq "Makefile location" "$AGENTS" ||
+  ! grep -Fq "Makefile location" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Project guidance must document location-independent Make paths." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- derive an override-protected repository root from the loaded Makefile
- resolve the portable checker and both Xcode project targets from that root
- add static contracts, documentation, and completed verification evidence

## Why

`make check` passed only from the repository root. Invoking the same Makefile from an external working directory failed before validation because the checker and Xcode project paths were relative to the caller.

## Validation

- `make check` from the repository root
- external-directory `make check` with both environment and command-line `ROOT=/tmp/poison` attempts
- bounded fake-Xcode execution of `xcode-list` and `xcode-build`, confirming absolute project paths and preserved simulator/signing flags
- six isolated hostile mutations rejected
- exact six-file diff with no Swift, storyboard, Xcode project, workflow, asset, artifact, or credential-shaped changes

## Platform Boundary

`xcodebuild` is not installed on this Linux host, so no local Xcode build is claimed. The stacked PR retains the canonical hosted macOS `make check` and unsigned simulator build.

## Stack

This PR is stacked on #6 (`lfg/emoji-imessage-remove-placeholder-20260613`). The base PR must remain available and merge first. Do not merge or close either PR without owner authorization.

## Baseline

The original pull request body did not record this fleet-standard section; its code baseline and historical discussion remain unchanged.

## Improvements

The implementation intent remains the Swift, sticker asset, accessibility, attribution, or build change described by the pull request title and original body: Make verification location independent.

## Risk

This description-only normalization changes no Swift source, bundled sticker asset, signing configuration, commit, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; manual Messages and VoiceOver verification limits remain tracked in the engineering-bar evidence.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this update changes pull request metadata only and has no production/runtime impact.
